### PR TITLE
Use Ubuntu images from AWS registry

### DIFF
--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM public.ecr.aws/lts/ubuntu:focal
 
 ARG node_version=v14.15.0
 ARG yq_version=3.4.1

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM public.ecr.aws/lts/ubuntu:focal
 
 ARG dotnet_3_version=3.1
 ARG dotnet_3_package_version=3.1.410-1


### PR DESCRIPTION
These are images published by Canonical: https://ubuntu.com/security/docker-images

This should help avoid pull limits imposed by Docker Hub