### PR TITLE
Use Ubuntu Impish for aarch64

### DIFF
--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -37,6 +37,10 @@ RUN apt-get update \
 ##
 && apt-get install -y wget libusb-1.0-0 \
 ##
+## libcap2-bin, contains setcap
+##
+&& apt-get install -y libcap2-bin \
+##
 ## .NET Core 5
 ##
 && mkdir -p /usr/local/dotnet \

--- a/linux-arm64/Dockerfile
+++ b/linux-arm64/Dockerfile
@@ -1,4 +1,7 @@
-FROM public.ecr.aws/lts/ubuntu:focal
+# Use Ubuntu Impish (21.10), which should ship with glibc 2.34,
+# which should contain a fix for the libgomp issue:
+# https://sourceware.org/bugzilla/show_bug.cgi?id=25051
+FROM public.ecr.aws/ubuntu/ubuntu:impish
 
 ARG dotnet_3_version=3.1.413
 ARG dotnet_3_slug=dfd0ad22-3e47-432f-9aa1-f65b11a2ced2/d096c5d1561732c1658543fa8fb7a31f

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -92,6 +92,10 @@ RUN apt-get update \
 ##
 && apt-get install -y wget libusb-1.0-0 \
 ##
+## libcap2-bin, contains setcap
+##
+&& apt-get install -y libcap2-bin \
+##
 ## git, tzdata
 ##
 && apt-get install -y git tzdata \


### PR DESCRIPTION
Should be a workaround for https://github.com/dotnet/runtime/issues/53002